### PR TITLE
fix: make action compatible with `macos-latest`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -59,7 +59,8 @@ runs:
     - name: Install cython
       if: (runner.os == 'linux' || runner.os == 'macos') && steps.cache-vs.outputs.cache-hit != 'true'
       shell: bash
-      run: pip3 install "cython==${{ inputs.cython-version }}"
+      run: |
+        pip3 install --break-system-packages "cython==${{ inputs.cython-version }}"
 
     - name: Install automake
       if: runner.os == 'macos' && (steps.cache-vs.outputs.cache-hit != 'true' || steps.cache-zimg.outputs.cache-hit != 'true')

--- a/action.yml
+++ b/action.yml
@@ -57,16 +57,19 @@ runs:
         echo "PREFIX=/usr/local" >> $GITHUB_ENV
 
     - name: Install cython
-      if: (runner.os == 'linux' || runner.os == 'macos') && steps.cache-vs.outputs.cache-hit != 'true'
+      if: runner.os == 'linux' && steps.cache-vs.outputs.cache-hit != 'true'
       shell: bash
-      run: |
-        pip3 install --break-system-packages "cython==${{ inputs.cython-version }}"
+      run: pip3 install "cython==${{ inputs.cython-version }}"
+
+    - name: Install cython
+      if: runner.os == 'macos' && steps.cache-vs.outputs.cache-hit != 'true'
+      shell: bash
+      run: pip3 install --break-system-packages "cython==${{ inputs.cython-version }}"
 
     - name: Install automake
       if: runner.os == 'macos' && (steps.cache-vs.outputs.cache-hit != 'true' || steps.cache-zimg.outputs.cache-hit != 'true')
       shell: bash
-      run: |
-        brew install autoconf automake hidapi libzip libtool
+      run: brew install automake libtool
 
     - name: Make zimg
       if: (runner.os == 'linux' || runner.os == 'macos') && steps.cache-zimg.outputs.cache-hit != 'true'

--- a/action.yml
+++ b/action.yml
@@ -66,7 +66,7 @@ runs:
       if: runner.os == 'macos' && (steps.cache-vs.outputs.cache-hit != 'true' || steps.cache-zimg.outputs.cache-hit != 'true')
       shell: bash
       run: |
-        brew install automake
+        brew install autoconf automake hidapi libzip libtool
 
     - name: Make zimg
       if: (runner.os == 'linux' || runner.os == 'macos') && steps.cache-zimg.outputs.cache-hit != 'true'


### PR DESCRIPTION
GitHub updated `macos-latest` from `OSX 12 x64` to `OSX 14 arm64`, which broke OSX CI.

* fix: update `pip3` command to install `cython` system-wide
* fix: install `libtool` with `brew`
